### PR TITLE
feat: store scraper run timestamp and created count in DB

### DIFF
--- a/apps/scraper/tests/scraper.spec.ts
+++ b/apps/scraper/tests/scraper.spec.ts
@@ -38,6 +38,8 @@ test.describe('Scrape Mercari', () => {
   });
 
   test('Scrape Items', async ({ page }) => {
+    let createdCount = 0;
+
     for (const record of keywords) {
       // Block images to speed up the loading time.
       await page.route('**/*', (route) => {
@@ -137,6 +139,7 @@ test.describe('Scrape Mercari', () => {
                 }
               }
             });
+            createdCount++;
           } else {
             const existingKeywordRelation = existingRecord.keywords.some(
               (k: { id: string }) => k.id === record.id
@@ -169,5 +172,9 @@ test.describe('Scrape Mercari', () => {
         console.log(`No items found for keyword: ${record.keyword}`);
       }
     }
+
+    await prisma.scraperRun.create({
+      data: { completedAt: new Date(), createdCount }
+    });
   });
 });

--- a/apps/web/app/(public)/_components/home-page.client.tsx
+++ b/apps/web/app/(public)/_components/home-page.client.tsx
@@ -31,8 +31,10 @@ export default function HomePageClient() {
     })
   );
 
+  const { data: lastRun } = useQuery(trpc.scraper.getLastRun.queryOptions());
+
   const keywords = keywordPage?.data ?? [];
-  const latestUpdateTime = keywords?.[0]?.updatedAt ?? 'N/A';
+  const latestUpdateTime = lastRun?.completedAt ?? 'N/A';
 
   const resultQueries = useQueries({
     queries:

--- a/apps/web/trpc/routers/scraper.ts
+++ b/apps/web/trpc/routers/scraper.ts
@@ -270,6 +270,11 @@ export const scraperRouter = router({
       }
     });
   }),
+  getLastRun: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db.scraperRun.findFirst({
+      orderBy: { completedAt: 'desc' }
+    });
+  }),
   createKeyword: protectedProcedure
     .input(
       z.object({

--- a/packages/database/prisma/migrations/20260219000000_add_scraper_run/migration.sql
+++ b/packages/database/prisma/migrations/20260219000000_add_scraper_run/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "ScraperRun" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ScraperRun_pkey" PRIMARY KEY ("id")
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -49,3 +49,10 @@ model KeywordCategory {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model ScraperRun {
+  id           String   @id @default(uuid()) @db.Uuid
+  completedAt  DateTime @default(now())
+  createdCount Int      @default(0)
+  createdAt    DateTime @default(now())
+}


### PR DESCRIPTION
- Add ScraperRun model to Prisma schema with completedAt and createdCount fields
- Add migration for ScraperRun table
- Update scraper to track new records count and write ScraperRun on completion
- Add getLastRun tRPC endpoint to fetch latest scraper run
- Update homepage to display actual scraper completion time instead of keyword updatedAt

https://claude.ai/code/session_01YDYbHQycGXeTB3DvWeGTKo