### PR TITLE
feat: send Slack notification after scraper completes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ AUTH_GOOGLE_ID="your-google-client-id"
 AUTH_GOOGLE_SECRET="your-google-client-secret"
 # Comma-separated list of allowed emails for authentication
 AUTH_ALLOW_EMAILS="user1@example.com,user2@example.com"
+
+# Production URL shown in Slack notifications (optional)
+NEXT_PUBLIC_APP_URL="https://your-app.vercel.app"
+
+# Slack Incoming Webhook URL for scraper completion notifications (optional)
+# If not set, notifications are silently skipped
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/apps/scraper/lib/slack.ts
+++ b/apps/scraper/lib/slack.ts
@@ -1,0 +1,26 @@
+export async function notifySlack({
+  createdCount,
+  appUrl
+}: {
+  createdCount: number;
+  appUrl?: string;
+}): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) return;
+
+  const linkPart = appUrl ? ` <${appUrl}|View results>` : '';
+  const text = `:white_check_mark: Mercari scraper completed. ${createdCount} new item${createdCount === 1 ? '' : 's'} found.${linkPart}`;
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    if (!res.ok) {
+      console.error(`Slack notification failed: HTTP ${res.status}`);
+    }
+  } catch (e) {
+    console.error('Slack notification error:', e);
+  }
+}

--- a/apps/scraper/tests/scraper.spec.ts
+++ b/apps/scraper/tests/scraper.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@playwright/test';
 import { getMercariUrl } from '../lib/utils';
+import { notifySlack } from '../lib/slack';
 import { PrismaClient, type ScraperKeyword } from '@mercari-scraper/database';
 
 // Set the viewport size for the page to ensure all items are visible.
@@ -176,5 +177,7 @@ test.describe('Scrape Mercari', () => {
     await prisma.scraperRun.create({
       data: { completedAt: new Date(), createdCount }
     });
+
+    await notifySlack({ createdCount, appUrl: process.env.NEXT_PUBLIC_APP_URL });
   });
 });

--- a/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/design.md
+++ b/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The scraper is a Playwright test (`apps/scraper/tests/scraper.spec.ts`) that runs daily via GitHub Actions. After completing, it creates a `ScraperRun` DB record. Currently there is no outbound notification — users must check the web UI or GitHub Actions logs to know the run finished.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Send a Slack message on successful scraper completion
+- Include new item count and a link to the production site
+- Keep the Slack integration fully optional (controlled by env vars)
+- Zero new npm dependencies (use native `fetch`)
+
+**Non-Goals:**
+- Notify on failure or partial failure
+- Support multiple Slack channels or workspaces
+- Retry on Slack API errors (failure is silent, not fatal)
+
+## Decisions
+
+### D1: Native `fetch` instead of `@slack/web-api`
+
+The scraper only needs one Slack call (POST to a webhook). Using the official SDK adds ~500 KB of dependencies for minimal benefit. Native `fetch` (available in Node 18+, already used by Playwright's environment) is sufficient.
+
+Alternatives considered:
+- `@slack/web-api`: richer types and error handling, but overkill for a single fire-and-forget webhook call
+
+### D2: Incoming Webhook instead of Bot API (`SLACK_WEBHOOK_URL`)
+
+A single Incoming Webhook URL encapsulates the token, channel, and workspace — no need to manage `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` separately. If the var is absent, the helper returns early with no error.
+
+Alternatives considered:
+- Bot API (`chat.postMessage`): more flexible (dynamic channel), but requires two separate secrets and a Slack App with scopes
+
+### D3: Non-fatal Slack errors
+
+If the Slack API call fails (network error, invalid token, channel not found), the error is logged to stderr but does not throw. The `ScraperRun` record has already been written to DB — the scraper result should not be invalidated by a notification failure.
+
+### D4: `NEXT_PUBLIC_APP_URL` for production link
+
+The production URL is already a logical env var for the web app. Reusing the same name keeps it consistent. In GitHub Actions it can be added as a secret or a plain env var.
+
+## Risks / Trade-offs
+
+- **Webhook URL leaked in logs** → Mitigation: never log the URL value, only log a generic failure message
+- **Slack rate limits** → Mitigation: one message per scraper run (once daily), far below limits
+- **Silent failure** → Mitigation: console.error logs the failure reason so it shows in GitHub Actions output
+
+## Migration Plan
+
+1. Add `SLACK_WEBHOOK_URL` and `NEXT_PUBLIC_APP_URL` to repo secrets in GitHub
+2. Update GitHub Actions workflow to expose them as env vars
+3. Deploy (no DB migration needed)
+4. Verify notification in Slack after next scheduled run
+
+Rollback: remove the two secrets — notification silently skips.

--- a/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/proposal.md
+++ b/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+After the scraper runs daily, there's no proactive way to know it completed successfully or how many new items were found. A Slack notification on completion gives immediate visibility without having to check the web UI or GitHub Actions logs.
+
+## What Changes
+
+- Add optional Slack notification sent at the end of a successful scraper run
+- Notification includes the count of newly created items and a link to the production site
+- Notification is gated on `SLACK_WEBHOOK_URL` environment variable — if absent, scraping proceeds silently as before
+- Add `NEXT_PUBLIC_APP_URL` env var to supply the production link in the message
+- Update `.env.example` with the two new optional variables
+- Update GitHub Actions workflow to pass the secrets to the scraper job
+
+## Capabilities
+
+### New Capabilities
+
+- `slack-scraper-notification`: Send a Slack message via Incoming Webhook after a successful scraper run, including new item count and production URL
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `apps/scraper/tests/scraper.spec.ts` — call notification helper after `ScraperRun` is created
+- `apps/scraper/lib/slack.ts` — new utility (fetch-based, no extra dependency)
+- `apps/scraper/.env.example` (and root `.env.example`) — document `SLACK_WEBHOOK_URL`, `NEXT_PUBLIC_APP_URL`
+- `.github/workflows/scraper.yml` — add two env vars read from GitHub secrets

--- a/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/specs/slack-scraper-notification/spec.md
+++ b/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/specs/slack-scraper-notification/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Notify Slack on successful scraper completion
+After a scraper run completes successfully, the system SHALL send a Slack message if `SLACK_WEBHOOK_URL` environment variable is present.
+
+#### Scenario: Notification sent when webhook URL is configured
+- **WHEN** the scraper finishes and `SLACK_WEBHOOK_URL` is set
+- **THEN** a message is POSTed to the webhook URL containing the count of newly created items and a link constructed from `NEXT_PUBLIC_APP_URL`
+
+#### Scenario: Notification silently skipped when webhook URL is absent
+- **WHEN** `SLACK_WEBHOOK_URL` is not set
+- **THEN** no HTTP call is made and the scraper exits normally without error
+
+### Requirement: Notification content
+The Slack message SHALL include the count of newly created `ScraperResult` records from the current run and a clickable link to the production site.
+
+#### Scenario: Message includes item count
+- **WHEN** the notification is sent
+- **THEN** the message text contains the `createdCount` value (e.g., "42 new items found")
+
+#### Scenario: Message includes production URL
+- **WHEN** `NEXT_PUBLIC_APP_URL` is set
+- **THEN** the message includes a link using that URL
+
+#### Scenario: Message omits link when URL is not set
+- **WHEN** `NEXT_PUBLIC_APP_URL` is not set
+- **THEN** the message is still sent without a link
+
+### Requirement: Non-fatal Slack errors
+A failure in the Slack notification (network error, invalid token, bad channel) SHALL NOT cause the scraper process to exit with a non-zero code or prevent the `ScraperRun` record from being written.
+
+#### Scenario: Slack API error is logged but not thrown
+- **WHEN** the Slack API returns an error or the request fails
+- **THEN** the error is logged to stderr and the scraper exits successfully

--- a/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/tasks.md
+++ b/openspec/changes/archive/2026-02-23-slack-notification-on-scraper-complete/tasks.md
@@ -1,0 +1,12 @@
+## 1. Slack Utility
+
+- [x] 1.1 Create `apps/scraper/lib/slack.ts` with a `notifySlack({ createdCount, appUrl })` function that POSTs to `SLACK_WEBHOOK_URL` via native `fetch`, returns early if `SLACK_WEBHOOK_URL` is missing, and catches errors with `console.error`
+
+## 2. Scraper Integration
+
+- [x] 2.1 Import and call `notifySlack` in `apps/scraper/tests/scraper.spec.ts` after `prisma.scraperRun.create`, passing `createdCount` and `process.env.NEXT_PUBLIC_APP_URL`
+
+## 3. Environment Configuration
+
+- [x] 3.1 Add `SLACK_WEBHOOK_URL` and `NEXT_PUBLIC_APP_URL` (both optional) to `.env.example` with comments explaining their purpose
+- [x] 3.2 Update `.github/workflows/scraper.yml` to expose `SLACK_WEBHOOK_URL` and `NEXT_PUBLIC_APP_URL` from GitHub secrets as environment variables in the scraper job

--- a/openspec/specs/slack-scraper-notification/spec.md
+++ b/openspec/specs/slack-scraper-notification/spec.md
@@ -1,0 +1,32 @@
+### Requirement: Notify Slack on successful scraper completion
+After a scraper run completes successfully, the system SHALL send a Slack message if `SLACK_WEBHOOK_URL` environment variable is present.
+
+#### Scenario: Notification sent when webhook URL is configured
+- **WHEN** the scraper finishes and `SLACK_WEBHOOK_URL` is set
+- **THEN** a message is POSTed to the webhook URL containing the count of newly created items and a link constructed from `NEXT_PUBLIC_APP_URL`
+
+#### Scenario: Notification silently skipped when webhook URL is absent
+- **WHEN** `SLACK_WEBHOOK_URL` is not set
+- **THEN** no HTTP call is made and the scraper exits normally without error
+
+### Requirement: Notification content
+The Slack message SHALL include the count of newly created `ScraperResult` records from the current run and a clickable link to the production site.
+
+#### Scenario: Message includes item count
+- **WHEN** the notification is sent
+- **THEN** the message text contains the `createdCount` value (e.g., "42 new items found")
+
+#### Scenario: Message includes production URL
+- **WHEN** `NEXT_PUBLIC_APP_URL` is set
+- **THEN** the message includes a link using that URL
+
+#### Scenario: Message omits link when URL is not set
+- **WHEN** `NEXT_PUBLIC_APP_URL` is not set
+- **THEN** the message is still sent without a link
+
+### Requirement: Non-fatal Slack errors
+A failure in the Slack notification (network error, invalid token, bad channel) SHALL NOT cause the scraper process to exit with a non-zero code or prevent the `ScraperRun` record from being written.
+
+#### Scenario: Slack API error is logged but not thrown
+- **WHEN** the Slack API returns an error or the request fails
+- **THEN** the error is logged to stderr and the scraper exits successfully


### PR DESCRIPTION
When SLACK_WEBHOOK_URL is set, post a message with the new item count and optional production link (NEXT_PUBLIC_APP_URL) after each run. Notification is fully optional and non-fatal on error.