### PR TITLE
feat: add resource monitor to scraper via globalSetup/globalTeardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,22 @@ The `scraper` app is set up to run automatically on a schedule using GitHub Acti
 3. Go to the GitHub project page → `Settings` → `Secrets and variables` → `Actions`, and add the following environment variables:
     - `DATABASE_URL`
     - `DIRECT_URL`
+    - `SLACK_WEBHOOK_URL` (optional) — enables Slack notifications on completion
     - Any other required environment variables
 4. On each scheduled trigger, GitHub Actions will automatically run the `scraper` and connect to the database.
+
+#### Resource Monitoring
+
+Every scraper run automatically samples CPU and RAM usage every 10 seconds via Node.js built-ins (no extra dependencies). After the run completes:
+
+- **Console** — a summary table is printed (duration, peak RAM, avg CPU, etc.)
+- **GitHub Actions** — the summary is also written to the [Job Summary](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary) page
+- **Slack** — if `SLACK_WEBHOOK_URL` is configured, a single message is sent combining the scrape result and resource stats:
+
+  ```
+  ✅ Mercari scraper completed. 42 new items found. View results
+  📊 3m 40s | RAM peak 1.84 GB | CPU avg 20.7% peak 37.9%
+  ```
 
 ---
 

--- a/apps/scraper/global-setup.ts
+++ b/apps/scraper/global-setup.ts
@@ -1,0 +1,35 @@
+import { spawn } from 'child_process';
+import { writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+export default async function globalSetup() {
+  const timestamp = Date.now();
+  const samplesFile = path.join(
+    os.tmpdir(),
+    `mercari-scraper-samples-${timestamp}.jsonl`
+  );
+  const pidFile = path.join(
+    os.tmpdir(),
+    `mercari-scraper-pid-${timestamp}.txt`
+  );
+  const metaFile = path.join(os.tmpdir(), 'mercari-scraper-monitor-meta.json');
+  const resultsFile = path.join(os.tmpdir(), 'mercari-scraper-results.json');
+
+  writeFileSync(
+    metaFile,
+    JSON.stringify({ samplesFile, pidFile, resultsFile })
+  );
+
+  const samplerPath = path.join(process.cwd(), 'sampler.mjs');
+
+  const child = spawn(process.execPath, [samplerPath, samplesFile], {
+    detached: true,
+    stdio: 'ignore'
+  });
+  child.unref();
+
+  writeFileSync(pidFile, String(child.pid));
+
+  console.log(`[monitor] Started resource sampler (PID: ${child.pid})`);
+}

--- a/apps/scraper/global-teardown.ts
+++ b/apps/scraper/global-teardown.ts
@@ -1,0 +1,144 @@
+import { appendFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { notifySlackSummary } from './lib/slack';
+
+interface Sample {
+  ts: number;
+  freeMem: number;
+  totalMem: number;
+  cpuPercent: number;
+}
+
+interface Meta {
+  samplesFile: string;
+  pidFile: string;
+  resultsFile: string;
+}
+
+interface ScraperResult {
+  createdCount?: number;
+  appUrl?: string;
+  error?: string;
+}
+
+function fmt(bytes: number): string {
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function fmtDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  return `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function cleanup(...files: string[]) {
+  for (const f of files) {
+    try {
+      unlinkSync(f);
+    } catch {
+      // ignore missing files
+    }
+  }
+}
+
+export default async function globalTeardown() {
+  const metaFile = path.join(os.tmpdir(), 'mercari-scraper-monitor-meta.json');
+
+  if (!existsSync(metaFile)) {
+    console.log('[monitor] No monitor session found, skipping summary');
+    return;
+  }
+
+  const meta: Meta = JSON.parse(readFileSync(metaFile, 'utf-8'));
+  const { samplesFile, pidFile, resultsFile } = meta;
+
+  // Kill sampler process
+  if (existsSync(pidFile)) {
+    const pid = parseInt(readFileSync(pidFile, 'utf-8'), 10);
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Process may have already exited
+    }
+  }
+
+  if (!existsSync(samplesFile)) {
+    console.log('[monitor] No samples collected');
+    cleanup(metaFile, pidFile, samplesFile);
+    return;
+  }
+
+  const lines = readFileSync(samplesFile, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  const samples: Sample[] = lines.map((l) => JSON.parse(l));
+
+  if (samples.length === 0) {
+    console.log('[monitor] No samples collected');
+    cleanup(metaFile, pidFile, samplesFile);
+    return;
+  }
+
+  const totalMem = samples[0].totalMem;
+  const durationMs = samples[samples.length - 1].ts - samples[0].ts;
+
+  const usedMems = samples.map((s) => totalMem - s.freeMem);
+  const peakRam = Math.max(...usedMems);
+  const avgRam = usedMems.reduce((a, b) => a + b, 0) / usedMems.length;
+
+  // Skip first sample for CPU (no delta on first reading)
+  const cpuValues = samples.slice(1).map((s) => s.cpuPercent);
+  const avgCpu =
+    cpuValues.length > 0
+      ? cpuValues.reduce((a, b) => a + b, 0) / cpuValues.length
+      : 0;
+  const peakCpu = cpuValues.length > 0 ? Math.max(...cpuValues) : 0;
+
+  // Console output
+  console.log('\n=== Resource Usage ===');
+  console.log(`Duration  : ${fmtDuration(durationMs)}`);
+  console.log(`Samples   : ${samples.length}`);
+  console.log(`RAM total : ${fmt(totalMem)}`);
+  console.log(
+    `RAM peak  : ${fmt(peakRam)} (${Math.round((peakRam / totalMem) * 100)}%)`
+  );
+  console.log(
+    `RAM avg   : ${fmt(avgRam)} (${Math.round((avgRam / totalMem) * 100)}%)`
+  );
+  console.log(`CPU avg   : ${avgCpu.toFixed(1)}%`);
+  console.log(`CPU peak  : ${peakCpu.toFixed(1)}%`);
+  console.log('======================\n');
+
+  // Slack notification
+  const scraperResult: ScraperResult | null = existsSync(resultsFile)
+    ? JSON.parse(readFileSync(resultsFile, 'utf-8'))
+    : null;
+
+  await notifySlackSummary({
+    result: scraperResult,
+    resource: { durationMs, totalMem, peakRam, avgCpu, peakCpu }
+  });
+
+  // GitHub Actions Step Summary
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const md = [
+      '### Resource Usage',
+      '',
+      '| Metric | Value |',
+      '|--------|-------|',
+      `| Duration | ${fmtDuration(durationMs)} |`,
+      `| Samples | ${samples.length} |`,
+      `| RAM total | ${fmt(totalMem)} |`,
+      `| RAM peak | ${fmt(peakRam)} (${Math.round((peakRam / totalMem) * 100)}%) |`,
+      `| RAM avg | ${fmt(avgRam)} (${Math.round((avgRam / totalMem) * 100)}%) |`,
+      `| CPU avg | ${avgCpu.toFixed(1)}% |`,
+      `| CPU peak | ${peakCpu.toFixed(1)}% |`,
+      ''
+    ].join('\n');
+
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
+  }
+
+  cleanup(metaFile, pidFile, samplesFile, resultsFile);
+}

--- a/apps/scraper/lib/slack.ts
+++ b/apps/scraper/lib/slack.ts
@@ -16,6 +16,50 @@ async function sendSlackMessage(text: string): Promise<void> {
   }
 }
 
+export async function notifySlackSummary({
+  result,
+  resource
+}: {
+  result: {
+    createdCount?: number;
+    appUrl?: string;
+    error?: string;
+  } | null;
+  resource: {
+    durationMs: number;
+    totalMem: number;
+    peakRam: number;
+    avgCpu: number;
+    peakCpu: number;
+  } | null;
+}): Promise<void> {
+  const resourceLine = resource
+    ? (() => {
+        const fmt = (b: number) => `${(b / 1024 / 1024 / 1024).toFixed(2)} GB`;
+        const s = Math.floor(resource.durationMs / 1000);
+        const duration = `${Math.floor(s / 60)}m ${s % 60}s`;
+        return `:bar_chart: ${duration} | RAM peak ${fmt(resource.peakRam)} | CPU avg ${resource.avgCpu.toFixed(1)}% peak ${resource.peakCpu.toFixed(1)}%`;
+      })()
+    : null;
+
+  let text: string;
+  if (result?.error) {
+    text = `:x: Mercari scraper failed.\n\`\`\`${result.error}\`\`\``;
+    if (resourceLine) text += `\n${resourceLine}`;
+  } else if (result) {
+    const count = result.createdCount ?? 0;
+    const linkPart = result.appUrl ? ` <${result.appUrl}|View results>` : '';
+    text = `:white_check_mark: Mercari scraper completed. ${count} new item${count === 1 ? '' : 's'} found.${linkPart}`;
+    if (resourceLine) text += `\n${resourceLine}`;
+  } else if (resourceLine) {
+    text = resourceLine;
+  } else {
+    return;
+  }
+
+  await sendSlackMessage(text);
+}
+
 export async function notifySlack({
   createdCount,
   appUrl

--- a/apps/scraper/playwright.config.ts
+++ b/apps/scraper/playwright.config.ts
@@ -12,6 +12,8 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
   testDir: './tests',
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/apps/scraper/sampler.mjs
+++ b/apps/scraper/sampler.mjs
@@ -1,0 +1,57 @@
+import os from 'os';
+import fs from 'fs';
+
+const [samplesFile] = process.argv.slice(2);
+
+if (!samplesFile) {
+  console.error('Usage: node sampler.mjs <samplesFile>');
+  process.exit(1);
+}
+
+const MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes
+const INTERVAL_MS = 10_000; // 10 seconds
+const startTime = Date.now();
+
+function getCpuTicks() {
+  const cpus = os.cpus();
+  let idle = 0;
+  let total = 0;
+  for (const cpu of cpus) {
+    idle += cpu.times.idle;
+    total += Object.values(cpu.times).reduce((a, b) => a + b, 0);
+  }
+  return { idle, total };
+}
+
+let prevCpuTicks = getCpuTicks();
+
+function sample() {
+  const now = getCpuTicks();
+  const deltaIdle = now.idle - prevCpuTicks.idle;
+  const deltaTotal = now.total - prevCpuTicks.total;
+  const cpuPercent = deltaTotal > 0 ? (1 - deltaIdle / deltaTotal) * 100 : 0;
+  prevCpuTicks = now;
+
+  const record = {
+    ts: Date.now(),
+    freeMem: os.freemem(),
+    totalMem: os.totalmem(),
+    cpuPercent: Math.round(cpuPercent * 10) / 10
+  };
+
+  fs.appendFileSync(samplesFile, JSON.stringify(record) + '\n');
+}
+
+// Take initial sample immediately
+sample();
+
+const interval = setInterval(() => {
+  sample();
+  if (Date.now() - startTime >= MAX_DURATION_MS) {
+    clearInterval(interval);
+    process.exit(0);
+  }
+}, INTERVAL_MS);
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/openspec/changes/archive/2026-02-28-ci-resource-monitor/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-28-ci-resource-monitor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/archive/2026-02-28-ci-resource-monitor/design.md
+++ b/openspec/changes/archive/2026-02-28-ci-resource-monitor/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The scraper runs as a Playwright test suite (`tests/scraper.spec.ts`) with no existing global lifecycle hooks. It runs locally via `pnpm scraper` and in GitHub Actions via `ubuntu-latest`. No monitoring currently exists — resource consumption is invisible in both environments.
+
+Playwright supports `globalSetup` and `globalTeardown` hooks in `playwright.config.ts`, which run once before and after the entire test suite. These are the natural integration points for cross-cutting concerns like resource monitoring.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Sample RAM and CPU usage throughout the full scraper run
+- Output a readable summary after each run
+- Work identically on macOS (local) and Linux (GitHub Actions) without configuration
+- Display richer output in GitHub Actions Step Summary when available
+
+**Non-Goals:**
+- Per-keyword or per-test resource breakdowns
+- Persistent storage of metrics across runs
+- Alerting or thresholds (no failure on high usage)
+- Windows support
+
+## Decisions
+
+### Use Playwright `globalSetup` / `globalTeardown` (vs. `beforeAll` / `afterAll`)
+
+`globalSetup` runs once per process, before any test worker spawns. `beforeAll` runs per worker. Since monitoring should track total process-level resources (not per-worker), `globalSetup`/`globalTeardown` is correct.
+
+Alternatives considered:
+- **Inline in `scraper.spec.ts`**: Mixes monitoring with scraper logic, harder to disable or extract.
+- **Separate shell wrapper script**: Requires platform-specific commands (`free` on Linux, `vm_stat` on macOS). Fragile.
+
+### Use Node.js `os` module (vs. shell commands or third-party packages)
+
+`os.freemem()`, `os.totalmem()`, `os.cpus()` are built-in, cross-platform, and zero-dependency. CPU % requires two samples and a diff of `idle` vs `total` ticks — straightforward to implement.
+
+Alternatives considered:
+- **`pidusage` / `systeminformation` npm packages**: Additional dependency for functionality we can implement in ~30 lines.
+- **Shell commands (`free`, `top`, `vm_stat`)**: Not cross-platform between macOS and Linux.
+
+### Store sampler state in a temp file (vs. in-memory / IPC)
+
+Playwright runs `globalSetup` and `globalTeardown` as separate Node.js processes. In-memory state is not shared between them. The sampler must be a persistent background process, or state must be passed via file or environment.
+
+Decision: the sampler runs as a **child process** (`node --input-type=module`) spawned by `globalSetup`, writes samples to a temp JSON file, and is terminated by `globalTeardown` which reads the file to compute the summary.
+
+Alternatives considered:
+- **Single long-running process**: Not possible — `globalSetup` exits after setup completes.
+- **Environment variable**: Can store a PID, but not accumulated samples.
+
+### Sampling interval: 10 seconds
+
+A typical scraper run is 3–6 minutes. At 10s intervals, we get 18–36 samples — enough for a meaningful trend. Shorter intervals add noise; longer intervals risk missing spikes.
+
+## Risks / Trade-offs
+
+- **`os.loadavg()` is always `[0,0,0]` on Windows** → Not a concern for this project (macOS + Linux only).
+- **Temp file cleanup on crash** → If the scraper process is killed mid-run, the temp file may persist. Risk is low (small file, OS cleans up on reboot). Mitigation: use `os.tmpdir()` path with a timestamped filename.
+- **Child process orphaning** → If `globalTeardown` never runs, the sampler process keeps running. Mitigation: sampler auto-exits after a maximum duration (e.g., 30 minutes).
+
+## Migration Plan
+
+1. Add `global-setup.ts` and `global-teardown.ts` to `apps/scraper/`
+2. Register both in `playwright.config.ts`
+3. No environment variables required; no secrets needed
+4. Rollback: remove the two `globalSetup`/`globalTeardown` entries from config

--- a/openspec/changes/archive/2026-02-28-ci-resource-monitor/proposal.md
+++ b/openspec/changes/archive/2026-02-28-ci-resource-monitor/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+When the Playwright scraper runs on GitHub Actions, resource usage is completely opaque. Chromium is a heavyweight process, and when scrapes fail or slow down, there's no way to determine if RAM exhaustion or CPU saturation is the cause. Local development also lacks a consistent way to observe resource consumption.
+
+## What Changes
+
+- Add `global-setup.ts`: starts a background sampler when the scraper launches, polling RAM and CPU every 10 seconds via Node.js `os` module
+- Add `global-teardown.ts`: stops the sampler when the scraper finishes and prints a summary (peak RAM, CPU trend)
+- Modify `playwright.config.ts` to register the new globalSetup and globalTeardown
+- Output adapts to environment: console table locally, additionally writes Markdown to `GITHUB_STEP_SUMMARY` on GitHub Actions
+
+## Capabilities
+
+### New Capabilities
+- `resource-monitor`: Background resource sampling during scraper runs, with environment-aware summary output (console vs GitHub Actions Step Summary)
+
+### Modified Capabilities
+
+## Impact
+
+- `apps/scraper/` — 2 new files (`global-setup.ts`, `global-teardown.ts`), 1 modified file (`playwright.config.ts`)
+- No new dependencies — uses only Node.js built-ins (`os`, `fs`)
+- No changes to scraper logic or database interactions

--- a/openspec/changes/archive/2026-02-28-ci-resource-monitor/specs/resource-monitor/spec.md
+++ b/openspec/changes/archive/2026-02-28-ci-resource-monitor/specs/resource-monitor/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Background sampling during scraper run
+The monitor SHALL start a background child process that samples RAM and CPU usage at a fixed 10-second interval for the duration of the scraper run.
+
+#### Scenario: Sampling starts before scraper tests begin
+- **WHEN** Playwright's globalSetup hook executes
+- **THEN** a background sampler process is spawned and begins recording samples immediately
+
+#### Scenario: Sampling stops after scraper tests finish
+- **WHEN** Playwright's globalTeardown hook executes
+- **THEN** the background sampler process is terminated and no further samples are recorded
+
+#### Scenario: Sampler auto-exits if teardown never runs
+- **WHEN** the sampler has been running for 30 minutes without being terminated
+- **THEN** the sampler process exits on its own
+
+### Requirement: Resource metrics collected per sample
+Each sample SHALL record timestamp, available RAM, total RAM, and per-core CPU idle/total ticks using the Node.js `os` module.
+
+#### Scenario: RAM data captured per sample
+- **WHEN** a sample is taken
+- **THEN** `os.freemem()` and `os.totalmem()` values are recorded in bytes
+
+#### Scenario: CPU data captured per sample
+- **WHEN** two consecutive samples are taken
+- **THEN** CPU usage percentage is calculated as `(1 - deltaIdle / deltaTotal) * 100` across all cores
+
+### Requirement: Summary output after scraper completes
+The monitor SHALL print a resource summary after all samples are collected, including peak RAM usage, average RAM usage, and average CPU percentage.
+
+#### Scenario: Console output on local run
+- **WHEN** `GITHUB_STEP_SUMMARY` environment variable is not set
+- **THEN** the summary is printed to stdout as a formatted text table
+
+#### Scenario: Step Summary output on GitHub Actions
+- **WHEN** `GITHUB_STEP_SUMMARY` environment variable is set to a file path
+- **THEN** the summary is appended to that file as a Markdown table
+- **THEN** the summary is also printed to stdout
+
+### Requirement: Samples persisted via temp file
+Samples SHALL be written to a JSON file in `os.tmpdir()` so that the teardown process (a separate Node.js process) can read them.
+
+#### Scenario: Temp file created on setup
+- **WHEN** globalSetup runs
+- **THEN** a timestamped temp file path is passed to the sampler process as an argument
+
+#### Scenario: Temp file read on teardown
+- **WHEN** globalTeardown runs
+- **THEN** the temp file is read, parsed, and used to compute the summary
+
+#### Scenario: Temp file deleted after teardown
+- **WHEN** globalTeardown finishes printing the summary
+- **THEN** the temp file is deleted from `os.tmpdir()`

--- a/openspec/changes/archive/2026-02-28-ci-resource-monitor/tasks.md
+++ b/openspec/changes/archive/2026-02-28-ci-resource-monitor/tasks.md
@@ -1,0 +1,14 @@
+## 1. Background Sampler Process
+
+- [x] 1.1 Create `apps/scraper/global-setup.ts` — spawn sampler child process, pass temp file path as argument, write PID to a second temp file for teardown to use
+- [x] 1.2 Create `apps/scraper/sampler.ts` — polling loop using `os.freemem()`, `os.totalmem()`, `os.cpus()` every 10 seconds, appending samples as JSON lines to temp file; auto-exit after 30 minutes
+
+## 2. Teardown and Summary
+
+- [x] 2.1 Create `apps/scraper/global-teardown.ts` — read PID file, kill sampler process, read samples file, compute summary (peak RAM, avg RAM, avg CPU %)
+- [x] 2.2 Implement summary output: plain text table to stdout always; additionally append Markdown table to `GITHUB_STEP_SUMMARY` when the env var is set
+- [x] 2.3 Delete temp files (samples + PID) after summary is printed
+
+## 3. Playwright Config
+
+- [x] 3.1 Add `globalSetup` and `globalTeardown` entries to `playwright.config.ts` pointing to the new files

--- a/openspec/specs/resource-monitor/spec.md
+++ b/openspec/specs/resource-monitor/spec.md
@@ -1,0 +1,60 @@
+# Resource Monitor
+
+## Purpose
+
+Monitors RAM and CPU usage during a scraper run by sampling system resources at a fixed interval in a background process, then printing a summary after the run completes.
+
+## Requirements
+
+### Requirement: Background sampling during scraper run
+The monitor SHALL start a background child process that samples RAM and CPU usage at a fixed 10-second interval for the duration of the scraper run.
+
+#### Scenario: Sampling starts before scraper tests begin
+- **WHEN** Playwright's globalSetup hook executes
+- **THEN** a background sampler process is spawned and begins recording samples immediately
+
+#### Scenario: Sampling stops after scraper tests finish
+- **WHEN** Playwright's globalTeardown hook executes
+- **THEN** the background sampler process is terminated and no further samples are recorded
+
+#### Scenario: Sampler auto-exits if teardown never runs
+- **WHEN** the sampler has been running for 30 minutes without being terminated
+- **THEN** the sampler process exits on its own
+
+### Requirement: Resource metrics collected per sample
+Each sample SHALL record timestamp, available RAM, total RAM, and per-core CPU idle/total ticks using the Node.js `os` module.
+
+#### Scenario: RAM data captured per sample
+- **WHEN** a sample is taken
+- **THEN** `os.freemem()` and `os.totalmem()` values are recorded in bytes
+
+#### Scenario: CPU data captured per sample
+- **WHEN** two consecutive samples are taken
+- **THEN** CPU usage percentage is calculated as `(1 - deltaIdle / deltaTotal) * 100` across all cores
+
+### Requirement: Summary output after scraper completes
+The monitor SHALL print a resource summary after all samples are collected, including peak RAM usage, average RAM usage, and average CPU percentage.
+
+#### Scenario: Console output on local run
+- **WHEN** `GITHUB_STEP_SUMMARY` environment variable is not set
+- **THEN** the summary is printed to stdout as a formatted text table
+
+#### Scenario: Step Summary output on GitHub Actions
+- **WHEN** `GITHUB_STEP_SUMMARY` environment variable is set to a file path
+- **THEN** the summary is appended to that file as a Markdown table
+- **THEN** the summary is also printed to stdout
+
+### Requirement: Samples persisted via temp file
+Samples SHALL be written to a JSON file in `os.tmpdir()` so that the teardown process (a separate Node.js process) can read them.
+
+#### Scenario: Temp file created on setup
+- **WHEN** globalSetup runs
+- **THEN** a timestamped temp file path is passed to the sampler process as an argument
+
+#### Scenario: Temp file read on teardown
+- **WHEN** globalTeardown runs
+- **THEN** the temp file is read, parsed, and used to compute the summary
+
+#### Scenario: Temp file deleted after teardown
+- **WHEN** globalTeardown finishes printing the summary
+- **THEN** the temp file is deleted from `os.tmpdir()`

--- a/turbo.json
+++ b/turbo.json
@@ -45,7 +45,8 @@
       "cache": false
     },
     "scraper": {
-      "cache": false
+      "cache": false,
+      "env": ["GITHUB_STEP_SUMMARY", "SCRAPE_CONCURRENCY"]
     },
     "scraper:debug": {
       "cache": false


### PR DESCRIPTION
Samples RAM and CPU every 10s using Node.js os module throughout the scraper run. After all tests complete, globalTeardown prints a summary (duration, peak RAM, avg RAM, CPU avg/peak), appends a Markdown table to GITHUB_STEP_SUMMARY on GitHub Actions, and sends a unified Slack message combining scrape results with resource stats.