### PR TITLE
fix(web-tanstack): remove double encoding of keyword in search naviga…

### DIFF
--- a/apps/web-tanstack/src/components/keyword-search.tsx
+++ b/apps/web-tanstack/src/components/keyword-search.tsx
@@ -57,7 +57,7 @@ export default function KeywordSearch({ className }: { className?: string }) {
         to: '/search',
         resetScroll: true,
         search: {
-          keyword: encodeURIComponent(target)
+          keyword: target
         }
       });
     } else {
@@ -80,7 +80,7 @@ export default function KeywordSearch({ className }: { className?: string }) {
     navigate({
       to: '/search',
       resetScroll: true,
-      search: { keyword: encodeURIComponent(keyword) }
+      search: { keyword: keyword }
     });
   };
 


### PR DESCRIPTION
…tion

TanStack Router handles URL encoding automatically; manually calling encodeURIComponent caused keywords with spaces to be double-encoded, breaking the match against keyword options in the search form.