### PR TITLE
fix(web-tanstack): improve PWA update handling

### DIFF
--- a/apps/web-tanstack/src/hooks/use-pwa-update-prompt.ts
+++ b/apps/web-tanstack/src/hooks/use-pwa-update-prompt.ts
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+export function usePwaUpdatePrompt() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+
+    let isDisposed = false;
+    let hasPrompted = false;
+
+    const promptForUpdate = (worker: ServiceWorker) => {
+      if (isDisposed) {
+        return;
+      }
+
+      if (hasPrompted) {
+        return;
+      }
+
+      hasPrompted = true;
+      toast.info('New version available', {
+        action: {
+          label: 'Update',
+          onClick: () => {
+            worker.addEventListener('statechange', () => {
+              if (worker.state === 'activated') {
+                window.location.reload();
+              }
+            });
+            worker.postMessage({ type: 'SKIP_WAITING' });
+          }
+        },
+        duration: Infinity
+      });
+    };
+
+    void navigator.serviceWorker
+      .register('/sw.js', { scope: '/' })
+      .then((registration) => {
+        if (registration.waiting && navigator.serviceWorker.controller) {
+          promptForUpdate(registration.waiting);
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const worker = registration.installing;
+
+          if (!worker) {
+            return;
+          }
+
+          worker.addEventListener('statechange', () => {
+            if (
+              worker.state === 'installed' &&
+              navigator.serviceWorker.controller
+            ) {
+              promptForUpdate(worker);
+            }
+          });
+        });
+
+        void registration.update();
+      });
+
+    return () => {
+      isDisposed = true;
+    };
+  }, []);
+}

--- a/apps/web-tanstack/src/hooks/use-scraper-foreground-refresh.spec.tsx
+++ b/apps/web-tanstack/src/hooks/use-scraper-foreground-refresh.spec.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScraperForegroundRefresh } from './use-scraper-foreground-refresh';
+
+const pathFilters = {
+  lastRun: { queryKey: ['scraper', 'getLastRun'] },
+  infiniteResults: { queryKey: ['scraper', 'infiniteResults'] }
+};
+
+vi.mock('@/router', () => ({
+  useTRPC: () => ({
+    scraper: {
+      getLastRun: {
+        pathFilter: () => pathFilters.lastRun
+      },
+      infiniteResults: {
+        pathFilter: () => pathFilters.infiniteResults
+      }
+    }
+  })
+}));
+
+describe('useScraperForegroundRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('refreshes scraper queries when the app returns to the foreground', () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useScraperForegroundRefresh(), { wrapper });
+
+    vi.setSystemTime(new Date('2026-06-15T00:00:02.000Z'));
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(invalidateQueries).toHaveBeenCalledWith(pathFilters.lastRun);
+    expect(invalidateQueries).toHaveBeenCalledWith(pathFilters.infiniteResults);
+  });
+
+  it('does not double refresh for duplicate foreground events', () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useScraperForegroundRefresh(), { wrapper });
+
+    vi.setSystemTime(new Date('2026-06-15T00:00:02.000Z'));
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    const pageShowEvent = new Event('pageshow') as PageTransitionEvent;
+    Object.defineProperty(pageShowEvent, 'persisted', { value: true });
+
+    window.dispatchEvent(pageShowEvent);
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web-tanstack/src/hooks/use-scraper-foreground-refresh.ts
+++ b/apps/web-tanstack/src/hooks/use-scraper-foreground-refresh.ts
@@ -1,0 +1,48 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { useTRPC } from '@/router';
+
+const MIN_REFRESH_INTERVAL_MS = 1000;
+
+export function useScraperForegroundRefresh() {
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+  const lastRefreshAtRef = useRef(0);
+
+  useEffect(() => {
+    const refreshScraperQueries = () => {
+      const now = Date.now();
+
+      if (now - lastRefreshAtRef.current < MIN_REFRESH_INTERVAL_MS) {
+        return;
+      }
+
+      lastRefreshAtRef.current = now;
+      void queryClient.invalidateQueries(trpc.scraper.getLastRun.pathFilter());
+      void queryClient.invalidateQueries(
+        trpc.scraper.infiniteResults.pathFilter()
+      );
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshScraperQueries();
+      }
+    };
+
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        refreshScraperQueries();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pageshow', handlePageShow);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pageshow', handlePageShow);
+    };
+  }, [queryClient, trpc]);
+}

--- a/apps/web-tanstack/src/routes/__root.tsx
+++ b/apps/web-tanstack/src/routes/__root.tsx
@@ -37,6 +37,8 @@ const ReactQueryDevtools = import.meta.env.PROD
 import AppHeader from '@/components/app-header';
 import { NotFound } from '@/components/not-found';
 import { Toaster } from '@/components/shadcn/sonner';
+import { usePwaUpdatePrompt } from '@/hooks/use-pwa-update-prompt';
+import { useScraperForegroundRefresh } from '@/hooks/use-scraper-foreground-refresh';
 import { useSessionCleanup } from '@/hooks/use-session-cleanup';
 
 import globalsCss from '../styles/globals.css?url';
@@ -106,6 +108,8 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 function RootLayout() {
   // Add session cleanup functionality
   useSessionCleanup();
+  usePwaUpdatePrompt();
+  useScraperForegroundRefresh();
 
   return (
     <html lang="en" className="dark">

--- a/apps/web-tanstack/vercel.json
+++ b/apps/web-tanstack/vercel.json
@@ -7,6 +7,33 @@
   "outputDirectory": "dist",
   "headers": [
     {
+      "source": "/sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/registerSW.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -37,9 +37,13 @@ export default defineConfig({
   },
   plugins: [
     VitePWA({
-      registerType: 'autoUpdate',
+      injectRegister: false,
+      registerType: 'prompt',
       outDir: '.output/public',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png'],
+      workbox: {
+        navigateFallback: null
+      },
       manifest: {
         name: 'Mercari Scraper',
         short_name: 'Mercari Scraper',


### PR DESCRIPTION
Prompt users when a new service worker is available and refresh scraper queries when the app returns to the foreground.

Disable Workbox navigation fallback for the SSR app and prevent stale PWA entry assets on Vercel.