### PR TITLE
feat(web-tanstack): remove result deletion controls

### DIFF
--- a/apps/web-tanstack/src/components/link-card.spec.tsx
+++ b/apps/web-tanstack/src/components/link-card.spec.tsx
@@ -1,6 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
 
 import LinkCard, { Props } from './link-card';
 
@@ -32,28 +30,9 @@ describe('ScraperResultCard', () => {
     expect(screen.getByText(/12,345 JPY/)).toBeInTheDocument();
   });
 
-  it('does not show delete button when disabled', () => {
+  it('does not show a delete button because result cards are browse-only', () => {
     render(<LinkCard {...props} />);
     expect(screen.queryByRole('button', { name: /delete item/i })).toBeNull();
-  });
-
-  it('shows delete button and triggers handler', async () => {
-    const user = userEvent.setup();
-    const handleDelete = vi.fn();
-
-    render(<LinkCard {...props} showDelete onDelete={handleDelete} />);
-
-    const deleteButton = screen.getByRole('button', { name: /delete item/i });
-    await user.click(deleteButton);
-
-    expect(handleDelete).toHaveBeenCalled();
-  });
-
-  it('disables delete button when deleting', () => {
-    render(<LinkCard {...props} showDelete isDeleting onDelete={() => {}} />);
-
-    const deleteButton = screen.getByRole('button', { name: /delete item/i });
-    expect(deleteButton).toBeDisabled();
   });
 
   it('does not show a NEW badge for first-seen items because no top-left badge means newly listed', () => {

--- a/apps/web-tanstack/src/components/link-card.tsx
+++ b/apps/web-tanstack/src/components/link-card.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@unpic/react';
-import { Trash2, Triangle } from 'lucide-react';
+import { Triangle } from 'lucide-react';
 export type Props = {
   url: string;
   title: string;
@@ -10,14 +10,9 @@ export type Props = {
   firstSeenRunId?: string | null;
   priceChangedRunId?: string | null;
   latestRunId?: string;
-  showDelete?: boolean;
-  isDeleting?: boolean;
-  onDelete?: () => void;
 };
 
 const LinkCard = (props: Props) => {
-  const shouldShowDelete =
-    props.showDelete && typeof props.onDelete === 'function';
   const priceDiff =
     props.latestRunId &&
     props.priceChangedRunId === props.latestRunId &&
@@ -65,22 +60,6 @@ const LinkCard = (props: Props) => {
             />
             {priceBadge.amount}
           </span>
-        )}
-        {shouldShowDelete && (
-          <button
-            type="button"
-            aria-label="Delete item"
-            disabled={props.isDeleting}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              props.onDelete?.();
-            }}
-            className="absolute right-2 top-2 z-10 rounded-md bg-black/60 px-2 py-1 text-xs font-medium text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-60 cursor-pointer flex items-center gap-1"
-          >
-            <Trash2 className="h-4 w-4" />
-            {props.isDeleting ? 'Deleting…' : 'Delete'}
-          </button>
         )}
       </div>
       <p className="absolute bottom-2 left-0 bg-gray-700/50 dark:bg-gray-950/80 py-2 px-3 text:lg sm:text-xl font-semibold text-white rounded-r-full">

--- a/apps/web-tanstack/src/components/virtual-result-grid.tsx
+++ b/apps/web-tanstack/src/components/virtual-result-grid.tsx
@@ -27,10 +27,6 @@ type Props = {
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
   fetchNextPage: () => void;
-  isAuthenticated: boolean;
-  deletingId: string | null;
-  isDeleting: boolean;
-  onDelete: (id: string) => void;
   latestRunId?: string;
 };
 
@@ -40,10 +36,6 @@ export default function VirtualResultGrid({
   isFetchingNextPage,
   hasNextPage,
   fetchNextPage,
-  isAuthenticated,
-  deletingId,
-  isDeleting,
-  onDelete,
   latestRunId
 }: Props) {
   const colCount = useColCount();
@@ -121,9 +113,6 @@ export default function VirtualResultGrid({
                   {rowItems.map((result) => (
                     <LinkCard
                       key={result.id ?? result.title + result.url}
-                      showDelete={isAuthenticated}
-                      isDeleting={deletingId === result.id && isDeleting}
-                      onDelete={() => onDelete(result.id)}
                       url={result.url}
                       title={result.title}
                       imageUrl={result.imageUrl}

--- a/apps/web-tanstack/src/routes/_public/search.tsx
+++ b/apps/web-tanstack/src/routes/_public/search.tsx
@@ -21,8 +21,6 @@ import {
   SheetTrigger
 } from '@/components/shadcn/sheet';
 import VirtualResultGrid from '@/components/virtual-result-grid';
-import { useDeleteResult } from '@/hooks/use-delete-result';
-import { useSession } from '@/lib/auth-client';
 import { useTRPC } from '@/router';
 
 const searchSchema = z.object({
@@ -77,7 +75,6 @@ export default function RouteComponent() {
   const formRef = useRef<HTMLFormElement>(null);
   const mobileFormRef = useRef<HTMLFormElement>(null);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
-  const { data: session } = useSession();
   const isHydrated = useHydrated();
   const navigate = useNavigate({ from: Route.fullPath });
   const { keyword, minPrice, maxPrice } = Route.useSearch();
@@ -119,10 +116,6 @@ export default function RouteComponent() {
       }
     )
   );
-  const { deleteResult, isDeleting } = useDeleteResult();
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-
-  const isAuthenticated = !!session;
   const allItems = infiniteResults?.pages.flatMap((p) => p.data) ?? [];
 
   const triggerSubmit = () => {
@@ -148,21 +141,6 @@ export default function RouteComponent() {
     });
   };
 
-  const handleDelete = async (id: string) => {
-    const shouldDelete = isHydrated
-      ? window.confirm('Are you sure you want to delete this item?')
-      : true;
-
-    if (!shouldDelete) return;
-
-    setDeletingId(id);
-    try {
-      await deleteResult(id);
-    } finally {
-      setDeletingId(null);
-    }
-  };
-
   return (
     <main className="container relative mx-auto flex gap-4 p-4">
       <div className="grow">
@@ -176,10 +154,6 @@ export default function RouteComponent() {
           isFetchingNextPage={isFetchingNextPage}
           hasNextPage={hasNextPage}
           fetchNextPage={fetchNextPage}
-          isAuthenticated={isAuthenticated}
-          deletingId={deletingId}
-          isDeleting={isDeleting}
-          onDelete={handleDelete}
         />
       </div>
 

--- a/apps/web-tanstack/src/routes/index.tsx
+++ b/apps/web-tanstack/src/routes/index.tsx
@@ -1,15 +1,8 @@
 import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
-import {
-  createFileRoute,
-  ErrorComponent,
-  useHydrated
-} from '@tanstack/react-router';
-import { useState } from 'react';
+import { createFileRoute, ErrorComponent } from '@tanstack/react-router';
 
 import TimeDisplay from '@/components/time-display';
 import VirtualResultGrid from '@/components/virtual-result-grid';
-import { useDeleteResult } from '@/hooks/use-delete-result';
-import { useSession } from '@/lib/auth-client';
 import { useTRPC } from '@/router';
 
 function Home() {
@@ -17,10 +10,6 @@ function Home() {
   const { data: lastRun } = useSuspenseQuery(
     trpc.scraper.getLastRun.queryOptions()
   );
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-  const { deleteResult, isDeleting } = useDeleteResult();
-  const { data: session } = useSession();
-  const isHydrated = useHydrated();
 
   const latestUpdateTime = lastRun?.completedAt;
   const latestRunId = lastRun?.id;
@@ -43,21 +32,6 @@ function Home() {
 
   const allItems = infiniteData?.pages.flatMap((p) => p.data) ?? [];
 
-  const isAuthenticated = !!session;
-
-  const handleDelete = async (id: string) => {
-    const shouldDelete = isHydrated
-      ? window.confirm('Are you sure you want to delete this item?')
-      : true;
-    if (!shouldDelete) return;
-    setDeletingId(id);
-    try {
-      await deleteResult(id);
-    } finally {
-      setDeletingId(null);
-    }
-  };
-
   return (
     <main className="mx-auto p-4 container relative">
       <div className="flex justify-end items-center mb-4">
@@ -73,10 +47,6 @@ function Home() {
         isFetchingNextPage={isFetchingNextPage}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
-        isAuthenticated={isAuthenticated}
-        deletingId={deletingId}
-        isDeleting={isDeleting}
-        onDelete={handleDelete}
         latestRunId={latestRunId}
       />
     </main>


### PR DESCRIPTION
Result cards are now browse-only, so remove the delete button, delete state wiring, and tests for the old interaction.