### PR TITLE
fix(web-tanstack): prevent white flash on iOS PWA resume

### DIFF
--- a/apps/web-tanstack/src/routes/__root.tsx
+++ b/apps/web-tanstack/src/routes/__root.tsx
@@ -79,6 +79,10 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         content: 'yes'
       },
       {
+        name: 'apple-mobile-web-app-status-bar-style',
+        content: 'black-translucent'
+      },
+      {
         name: 'apple-mobile-web-app-title',
         content: 'Mercari Scraper'
       }
@@ -112,7 +116,7 @@ function RootLayout() {
   useScraperForegroundRefresh();
 
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className="dark" style={{ backgroundColor: '#030712' }}>
       <head>
         <HeadContent />
       </head>


### PR DESCRIPTION
Add inline background-color on <html> so iOS renders dark immediately when restoring the app, before CSS loads. Add status-bar-style meta tag to keep the status bar area consistent.